### PR TITLE
Upstream stf_lib changes

### DIFF
--- a/lib/stf_inst.cpp
+++ b/lib/stf_inst.cpp
@@ -118,6 +118,6 @@ namespace stf {
     const boost::container::flat_set<descriptors::internal::Descriptor> STFInst::SKIPPED_PAIRED_RECORDS_ {
         descriptors::internal::Descriptor::STF_INST_MEM_CONTENT,
         descriptors::internal::Descriptor::STF_BUS_MASTER_CONTENT,
-        //descriptors::internal::Descriptor::STF_EVENT_PC_TARGET
+        descriptors::internal::Descriptor::STF_EVENT_PC_TARGET
     };
 } // end namespace stf

--- a/lib/stf_reg_def.cpp
+++ b/lib/stf_reg_def.cpp
@@ -392,6 +392,11 @@ namespace stf {
         os << "REG_" + std::to_string(Registers::getArchRegIndex(regno));
     }
 
+    void Registers::formatVector_(std::ostream& os, const Registers::STF_REG regno) {
+        stf_assert(isVector(regno), "Attempted to format a non-vector register: " << std::hex << enums::to_int(regno));
+        os << "REG_V" + std::to_string(Registers::getArchRegIndex(regno));
+    }
+
     Registers::STF_REG_packed_int Registers::getArchRegIndex(const Registers::STF_REG regno) {
         return Codec::packRegNum(regno);
     }
@@ -407,6 +412,9 @@ namespace stf {
         }
         else if (Registers::isGPR(regno)) {
             Registers::formatGPR_(os, regno);
+        }
+        else if (Registers::isVector(regno)) {
+            Registers::formatVector_(os, regno);
         }
         else {
             stf_throw("Invalid STF_REG_TYPE: " << Registers::Codec::getRegType(regno));

--- a/lib/stf_reg_state.cpp
+++ b/lib/stf_reg_state.cpp
@@ -36,6 +36,16 @@ namespace stf {
         return true ;
     }
 
+    STFRegState& STFRegState::operator=(const STFRegState& rhs) {
+        regbank = rhs.regbank;
+        regstate.clear();
+        for(const auto& p: rhs.regstate) {
+            regstate.emplace(p.first, p.second);
+        }
+
+        return *this;
+    }
+
     void STFRegState::getRegValue(Registers::STF_REG regno, uint64_t &data) const {
         Registers::STF_REG mapped_reg;
 

--- a/stf-inc/stf_inst.hpp
+++ b/stf-inc/stf_inst.hpp
@@ -324,6 +324,7 @@ namespace stf {
                 INST_IS_FP              = 1 << 8,   /**< inst is FP */
                 INST_CHANGE_TO_USER     = 1 << 9,   /**< inst changes to user mode */
                 INST_CHANGE_FROM_USER   = 1 << 10,  /**< inst changes from user mode */
+                INST_IS_FAULT           = 1 << 11,  /**< instruction is a fault */
             };
 
             uint64_t branch_target_ = 0; /**< branch target PC */
@@ -577,7 +578,7 @@ namespace stf {
              */
             inline void writeRecordPairs_(STFWriter& stf_writer,
                                           const descriptors::internal::Descriptor first_desc,
-                                          const RecordMap::VecType& first_record_vec,
+                                          const RecordMap::SmallVector& first_record_vec,
                                           const descriptors::internal::Descriptor second_desc) const {
                 const auto& second_vec = orig_records_.at(second_desc);
                 const bool is_event = first_desc == descriptors::internal::Descriptor::STF_EVENT;
@@ -872,6 +873,12 @@ namespace stf {
              * \return True if syscall
              */
             bool isSyscall() const { return inst_flags_ & INST_IS_SYSCALL; }
+
+            /**
+             * \brief Fault or not
+             * \return True if fault
+             */
+            bool isFault() const { return inst_flags_ & INST_IS_FAULT; }
 
             /**
              * \brief FP or not

--- a/stf-inc/stf_inst_reader.hpp
+++ b/stf-inc/stf_inst_reader.hpp
@@ -299,13 +299,13 @@ namespace stf {
                                                                                           STFInst::INST_CHANGE_FROM_USER};
 
                     const auto rec = readRecord_(inst);
-                    const auto desc = rec->getDescriptor();
 
                     if(!rec) {
                         event_valid = false;
                         continue;
                     }
 
+                    const auto desc = rec->getDescriptor();
                     stf_assert(desc != descriptors::internal::Descriptor::STF_INST_MEM_CONTENT,
                                "Saw MemContentRecord without accompanying MemAccessRecord");
 
@@ -366,6 +366,7 @@ namespace stf {
 
                                     inst.setInstFlag_(math_utils::conditionalValue(
                                         is_syscall, STFInst::INST_IS_SYSCALL,
+                                        event.isFault(), STFInst::INST_IS_FAULT,
                                         !is_syscall && (is_mode_change = event.isModeChange()), MODE_CHANGE_FLAGS[event.getData().front()]
                                     ));
 

--- a/stf-inc/stf_reg_def.hpp
+++ b/stf-inc/stf_reg_def.hpp
@@ -141,6 +141,14 @@ namespace stf {
             }
 
             /**
+             * Checks whether a register is a vector register
+             * \param regno STF_REG value to check
+             */
+            static inline constexpr bool isVector(const STF_REG regno) {
+                return Registers::Codec::getRegType(regno) == Registers::STF_REG_TYPE::VECTOR;
+            }
+
+            /**
              * Formats an STF_REG value into a stream
              * \param os stream to format into
              * \param regno STF_REG value to format
@@ -212,6 +220,11 @@ namespace stf {
             static void formatFPR_(std::ostream& os, Registers::STF_REG regno);
 
             /**
+             * Converts a vector register into its corresponding string representation
+             */
+            static void formatVector_(std::ostream& os, Registers::STF_REG regno);
+
+            /**
              * Converts a CSR into its corresponding string representation
              */
             static void formatCSR_(std::ostream& os, Registers::STF_REG regno);
@@ -253,7 +266,7 @@ namespace stf {
         STF_REG_X30              = Codec::combineRegType(0x001E, STF_REG_TYPE::INTEGER),
         STF_REG_X31              = Codec::combineRegType(0x001F, STF_REG_TYPE::INTEGER),
 
-        // 32 floating point  registers
+        // 32 floating point registers
         STF_REG_F0               = Codec::combineRegType(0x0000, STF_REG_TYPE::FLOATING_POINT),
         STF_REG_F1               = Codec::combineRegType(0x0001, STF_REG_TYPE::FLOATING_POINT),
         STF_REG_F2               = Codec::combineRegType(0x0002, STF_REG_TYPE::FLOATING_POINT),
@@ -286,6 +299,40 @@ namespace stf {
         STF_REG_F29              = Codec::combineRegType(0x001D, STF_REG_TYPE::FLOATING_POINT),
         STF_REG_F30              = Codec::combineRegType(0x001E, STF_REG_TYPE::FLOATING_POINT),
         STF_REG_F31              = Codec::combineRegType(0x001F, STF_REG_TYPE::FLOATING_POINT),
+
+        // 32 vector registers
+        STF_REG_V0               = Codec::combineRegType(0x0000, STF_REG_TYPE::VECTOR),
+        STF_REG_V1               = Codec::combineRegType(0x0001, STF_REG_TYPE::VECTOR),
+        STF_REG_V2               = Codec::combineRegType(0x0002, STF_REG_TYPE::VECTOR),
+        STF_REG_V3               = Codec::combineRegType(0x0003, STF_REG_TYPE::VECTOR),
+        STF_REG_V4               = Codec::combineRegType(0x0004, STF_REG_TYPE::VECTOR),
+        STF_REG_V5               = Codec::combineRegType(0x0005, STF_REG_TYPE::VECTOR),
+        STF_REG_V6               = Codec::combineRegType(0x0006, STF_REG_TYPE::VECTOR),
+        STF_REG_V7               = Codec::combineRegType(0x0007, STF_REG_TYPE::VECTOR),
+        STF_REG_V8               = Codec::combineRegType(0x0008, STF_REG_TYPE::VECTOR),
+        STF_REG_V9               = Codec::combineRegType(0x0009, STF_REG_TYPE::VECTOR),
+        STF_REG_V10              = Codec::combineRegType(0x000A, STF_REG_TYPE::VECTOR),
+        STF_REG_V11              = Codec::combineRegType(0x000B, STF_REG_TYPE::VECTOR),
+        STF_REG_V12              = Codec::combineRegType(0x000C, STF_REG_TYPE::VECTOR),
+        STF_REG_V13              = Codec::combineRegType(0x000D, STF_REG_TYPE::VECTOR),
+        STF_REG_V14              = Codec::combineRegType(0x000E, STF_REG_TYPE::VECTOR),
+        STF_REG_V15              = Codec::combineRegType(0x000F, STF_REG_TYPE::VECTOR),
+        STF_REG_V16              = Codec::combineRegType(0x0010, STF_REG_TYPE::VECTOR),
+        STF_REG_V17              = Codec::combineRegType(0x0011, STF_REG_TYPE::VECTOR),
+        STF_REG_V18              = Codec::combineRegType(0x0012, STF_REG_TYPE::VECTOR),
+        STF_REG_V19              = Codec::combineRegType(0x0013, STF_REG_TYPE::VECTOR),
+        STF_REG_V20              = Codec::combineRegType(0x0014, STF_REG_TYPE::VECTOR),
+        STF_REG_V21              = Codec::combineRegType(0x0015, STF_REG_TYPE::VECTOR),
+        STF_REG_V22              = Codec::combineRegType(0x0016, STF_REG_TYPE::VECTOR),
+        STF_REG_V23              = Codec::combineRegType(0x0017, STF_REG_TYPE::VECTOR),
+        STF_REG_V24              = Codec::combineRegType(0x0018, STF_REG_TYPE::VECTOR),
+        STF_REG_V25              = Codec::combineRegType(0x0019, STF_REG_TYPE::VECTOR),
+        STF_REG_V26              = Codec::combineRegType(0x001A, STF_REG_TYPE::VECTOR),
+        STF_REG_V27              = Codec::combineRegType(0x001B, STF_REG_TYPE::VECTOR),
+        STF_REG_V28              = Codec::combineRegType(0x001C, STF_REG_TYPE::VECTOR),
+        STF_REG_V29              = Codec::combineRegType(0x001D, STF_REG_TYPE::VECTOR),
+        STF_REG_V30              = Codec::combineRegType(0x001E, STF_REG_TYPE::VECTOR),
+        STF_REG_V31              = Codec::combineRegType(0x001F, STF_REG_TYPE::VECTOR),
 
         // Control and status registers
         // User

--- a/stf-inc/stf_reg_state.hpp
+++ b/stf-inc/stf_reg_state.hpp
@@ -128,6 +128,10 @@ namespace stf {
             };
 
             STFRegState() = default;
+            STFRegState(const STFRegState&) = default;
+            STFRegState(STFRegState&&) = default;
+            STFRegState& operator=(STFRegState&& rhs) = default;
+            STFRegState& operator=(const STFRegState& rhs);
 
             /**
              * Constructs and initializes an STFRegState


### PR DESCRIPTION
that the single-element optimization is handled properly
    - Fixes segfault in stf_dump when dumping PTEs

Fix segfault in STFInstReader when ignoring records
Flag faulting instructions in STFInstReader
Add vector register definitions and formatter
Fix assertion message in Registers::formatVector_
Add explicit copy assignment operator to STFRegState to fix compile errors on OSX
Fix duplicated EVENT_PC_TARGET records in stf_extract