### PR TITLE
Allow missing operand data in STFBranchReader

### DIFF
--- a/stf-inc/stf_branch.hpp
+++ b/stf-inc/stf_branch.hpp
@@ -66,7 +66,7 @@ namespace stf {
                             }
                         }
 
-                        stf_throw("Register " << reg_num << " not present in the map");
+                        return 0;
                     }
 
                     /**


### PR DESCRIPTION
Default to 0 if there aren't any InstRegRecords attached to the instruction.

stf_branch_hdf5 is the only tool that uses branch operand data, but users of that tool should be aware if their traces do or don't include operand values.