### PR TITLE
stfpy: Fixed wrong __next__ implementation

### DIFF
--- a/stfpy/stfpy/stf_branch_reader.pyx
+++ b/stfpy/stfpy/stf_branch_reader.pyx
@@ -9,11 +9,11 @@ include "stfpy/stf_lib/stf_reader_constants.pxi"
 
 cdef class STFBranchReaderIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return STFBranch._construct(dereference(self.c_it))
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = STFBranch._construct(dereference(self.c_it))
+        preincrement(self.c_it)
+        return value
 
 cdef class STFBranchReader:
     def __cinit__(self,

--- a/stfpy/stfpy/stf_inst.pxd
+++ b/stfpy/stfpy/stf_inst.pxd
@@ -1,6 +1,6 @@
 # distutils: language = c++
 
-from cython.operator cimport dereference, preincrement
+from cython.operator cimport dereference
 from stfpy.stf_lib.stf_record_types cimport VectorValueType as _VectorValueType, VectorValueTypeIterator as _VectorValueTypeIterator
 from stfpy.stf_lib.stf_inst cimport EventDataVector as _EventDataVector, EventDataVectorIterator as _EventDataVectorIterator, EventVectorIterator as _EventVectorIterator, OperandVectorIterator as _OperandVectorIterator, MemAccessVectorIterator as _MemAccessVectorIterator, Event as _Event, Operand as _Operand, MemAccess as _MemAccess, STFInst as _STFInst
 

--- a/stfpy/stfpy/stf_inst.pyx
+++ b/stfpy/stfpy/stf_inst.pyx
@@ -8,11 +8,11 @@ from stfpy.stf_record_map import STFRecordMap, STFRecordMapSmallVector
 
 cdef class EventDataVectorIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return dereference(self.c_it)
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = dereference(self.c_it)
+        preincrement(self.c_it)
+        return value
 
 cdef class EventDataVector:
     def __iter__(self):
@@ -54,11 +54,11 @@ cdef class Event:
 
 cdef class EventVectorIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return Event._construct(dereference(self.c_it))
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = Event._construct(dereference(self.c_it))
+        preincrement(self.c_it)
+        return value
 
 cdef class EventVector:
     def __iter__(self):
@@ -75,11 +75,11 @@ cdef class EventVector:
 
 cdef class VectorValueTypeIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return dereference(self.c_it)
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = dereference(self.c_it)
+        preincrement(self.c_it)
+        return value
 
 cdef class VectorValueType:
     def __iter__(self):
@@ -115,11 +115,11 @@ cdef class Operand:
 
 cdef class OperandVectorIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return Operand._construct(dereference(self.c_it))
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = Operand._construct(dereference(self.c_it))
+        preincrement(self.c_it)
+        return value
 
 cdef class OperandVector:
     def __iter__(self):
@@ -152,11 +152,11 @@ cdef class MemAccess:
 
 cdef class MemAccessVectorIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return MemAccess._construct(dereference(self.c_it))
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = MemAccess._construct(dereference(self.c_it))
+        preincrement(self.c_it)
+        return value
 
 cdef class MemAccessVector:
     def __iter__(self):

--- a/stfpy/stfpy/stf_inst_reader.pyx
+++ b/stfpy/stfpy/stf_inst_reader.pyx
@@ -9,11 +9,11 @@ include "stfpy/stf_lib/stf_reader_constants.pxi"
 
 cdef class STFInstReaderIterator:
     def __next__(self):
-        preincrement(self.c_it)
-        if self.c_it != self.c_end_it:
-            return STFInst._construct(dereference(self.c_it))
-        else:
+        if self.c_it == self.c_end_it:
             raise StopIteration
+        value = STFInst._construct(dereference(self.c_it))
+        preincrement(self.c_it)
+        return value
 
 cdef class STFInstReader:
     def __cinit__(self,


### PR DESCRIPTION
Iterator was falsely advanced every time before accessed. So the first record will be always ignored. Moreover, segmentation fault will be raised if the container is empty.