### PR TITLE
Fix compiler errors related to using an incomplete type with an std::unique_ptr

### DIFF
--- a/lib/stf_reader_base.cpp
+++ b/lib/stf_reader_base.cpp
@@ -7,6 +7,8 @@
 #include "zstd/stf_zstd_decompressor.hpp"
 
 namespace stf {
+    STFReaderBase::~STFReaderBase() = default;
+
     void STFReaderBase::validateHeader_() const {
         stf_assert(!trace_info_records_.empty(), "TRACE_INFO record missing from header");
         stf_assert(trace_features_, "TRACE_INFO_FEATURE record missing from header");

--- a/stf-inc/stf_reader_base.hpp
+++ b/stf-inc/stf_reader_base.hpp
@@ -62,6 +62,9 @@ namespace stf {
 
         public:
             STFReaderBase() = default;
+            ~STFReaderBase();
+            STFReaderBase(STFReaderBase&& rhs) = default;
+            STFReaderBase& operator=(STFReaderBase&& rhs) = default;
 
             /**
              * \brief Check STF and trace versions for compatibility


### PR DESCRIPTION
Deleter is malformed unless the destructor is defined in the STFReaderBase .cpp file.

Fixes build errors with newer compilers/C++ standards.