### PR TITLE
stfpy: Added support to get header comments

### DIFF
--- a/lib/stf_reader.cpp
+++ b/lib/stf_reader.cpp
@@ -42,6 +42,7 @@ namespace stf {
                 switch(rec->getId()) {
                     case descriptors::internal::Descriptor::STF_COMMENT:
                         header_comments_.emplace_back(STFRecord::grabOwnership<CommentRecord>(rec));
+                        header_comments_str_.emplace_back(header_comments_.back()->getData());
                         break;
                     case descriptors::internal::Descriptor::STF_ISA:
                         stf_assert(!isa_, "Header has multiple ISA records");

--- a/lib/stf_reader.cpp
+++ b/lib/stf_reader.cpp
@@ -42,7 +42,6 @@ namespace stf {
                 switch(rec->getId()) {
                     case descriptors::internal::Descriptor::STF_COMMENT:
                         header_comments_.emplace_back(STFRecord::grabOwnership<CommentRecord>(rec));
-                        header_comments_str_.emplace_back(header_comments_.back()->getData());
                         break;
                     case descriptors::internal::Descriptor::STF_ISA:
                         stf_assert(!isa_, "Header has multiple ISA records");

--- a/lib/stf_reader_base.cpp
+++ b/lib/stf_reader_base.cpp
@@ -76,6 +76,15 @@ namespace stf {
         return *trace_info_records_.back();
     }
 
+    const std::vector<std::string>& STFReaderBase::getHeaderCommentsString() {
+        if(!header_comments_.empty() && header_comments_str_.empty()) {
+            for(const auto& c : header_comments_) {
+                header_comments_str_.emplace_back(c->getData());
+            }
+        }
+        return header_comments_str_;
+    }
+
     int STFReaderBase::close() {
         version_.reset();
         header_comments_.clear();

--- a/stf-inc/stf_reader_base.hpp
+++ b/stf-inc/stf_reader_base.hpp
@@ -37,6 +37,7 @@ namespace stf {
         protected:
             STFRecord::ConstHandle<VersionRecord> version_; /**< Version record */
             std::vector<STFRecord::ConstHandle<CommentRecord>> header_comments_; /**< Header commment records */
+            std::vector<std::string> header_comments_str_; /** String type of header comments*/
             std::vector<STFRecord::ConstHandle<TraceInfoRecord>> trace_info_records_; /**< Trace info records */
             STFRecord::ConstHandle<TraceInfoFeatureRecord> trace_features_; /**< Trace feature records */
 
@@ -126,6 +127,17 @@ namespace stf {
              */
             inline const STFRecord::ConstHandle<TraceInfoFeatureRecord>& getTraceFeatures() const {
                 return trace_features_;
+            }
+
+            /**
+             * Gets the header comments
+             */
+            inline const std::vector<STFRecord::ConstHandle<CommentRecord>>& getHeaderComments() const {
+                return header_comments_;
+             }
+
+            inline const std::vector<std::string>& getHeaderCommentsString() const {
+                return header_comments_str_;
             }
 
             /**

--- a/stf-inc/stf_reader_base.hpp
+++ b/stf-inc/stf_reader_base.hpp
@@ -136,9 +136,10 @@ namespace stf {
                 return header_comments_;
              }
 
-            inline const std::vector<std::string>& getHeaderCommentsString() const {
-                return header_comments_str_;
-            }
+            /**
+             * Gets the header comments in vector type of std::string
+             */
+            const std::vector<std::string>& getHeaderCommentsString();
 
             /**
              * Returns the number of records read so far

--- a/stfpy/stfpy/stf_inst_reader.pxd
+++ b/stfpy/stfpy/stf_inst_reader.pxd
@@ -2,27 +2,27 @@
 
 from cython.operator cimport dereference
 from stfpy.stf_lib.stf_inst_reader cimport STFInstReader as _STFInstReader
-from stfpy.stf_lib.stf_inst_reader cimport StringVector as _StringVector, StringVectorIterator as _StringVectorIterator
+from stfpy.stf_lib.stf_inst_reader cimport HeaderCommentsType as _HeaderCommentsType, HeaderCommentsTypeIterator as _HeaderCommentsTypeIterator
 
 ctypedef _STFInstReader.iterator _STFInstReaderIterator
 
-cdef class StringVectorIterator:
-    cdef _StringVectorIterator c_it
-    cdef _StringVectorIterator c_end_it
+cdef class HeaderCommentsTypeIterator:
+    cdef _HeaderCommentsTypeIterator c_it
+    cdef _HeaderCommentsTypeIterator c_end_it
 
     @staticmethod
-    cdef inline StringVectorIterator _construct(const _StringVector* vec):
-        it = StringVectorIterator()
+    cdef inline HeaderCommentsTypeIterator _construct(const _HeaderCommentsType* vec):
+        it = HeaderCommentsTypeIterator()
         it.c_it = dereference(vec).begin()
         it.c_end_it = dereference(vec).end()
         return it
 
-cdef class StringVector:
-    cdef const _StringVector* c_vec
+cdef class HeaderCommentsType:
+    cdef const _HeaderCommentsType* c_vec
 
     @staticmethod
-    cdef inline StringVector _construct(const _StringVector& vec):
-        new_vec = StringVector()
+    cdef inline HeaderCommentsType _construct(const _HeaderCommentsType& vec):
+        new_vec = HeaderCommentsType()
         new_vec.c_vec = &vec
         return new_vec
 

--- a/stfpy/stfpy/stf_inst_reader.pxd
+++ b/stfpy/stfpy/stf_inst_reader.pxd
@@ -1,8 +1,30 @@
 # distutils: language = c++
 
+from cython.operator cimport dereference
 from stfpy.stf_lib.stf_inst_reader cimport STFInstReader as _STFInstReader
+from stfpy.stf_lib.stf_inst_reader cimport StringVector as _StringVector, StringVectorIterator as _StringVectorIterator
 
 ctypedef _STFInstReader.iterator _STFInstReaderIterator
+
+cdef class StringVectorIterator:
+    cdef _StringVectorIterator c_it
+    cdef _StringVectorIterator c_end_it
+
+    @staticmethod
+    cdef inline StringVectorIterator _construct(const _StringVector* vec):
+        it = StringVectorIterator()
+        it.c_it = dereference(vec).begin()
+        it.c_end_it = dereference(vec).end()
+        return it
+
+cdef class StringVector:
+    cdef const _StringVector* c_vec
+
+    @staticmethod
+    cdef inline StringVector _construct(const _StringVector& vec):
+        new_vec = StringVector()
+        new_vec.c_vec = &vec
+        return new_vec
 
 cdef class STFInstReaderIterator:
     cdef _STFInstReaderIterator c_it

--- a/stfpy/stfpy/stf_inst_reader.pyx
+++ b/stfpy/stfpy/stf_inst_reader.pyx
@@ -7,6 +7,27 @@ from stfpy.stf_inst import STFInst
 from cython.operator cimport dereference, preincrement
 include "stfpy/stf_lib/stf_reader_constants.pxi"
 
+cdef class StringVectorIterator:
+    def __next__(self):
+        if self.c_it == self.c_end_it:
+            raise StopIteration
+        value = dereference(self.c_it)
+        preincrement(self.c_it)
+        return value
+
+cdef class StringVector:
+    def __iter__(self):
+        return StringVectorIterator._construct(self.c_vec)
+
+    def __len__(self):
+        return dereference(self.c_vec).size()
+
+    def __getitem__(self, idx):
+        return dereference(self.c_vec).at(idx)
+
+    def __bool__(self):
+        return not dereference(self.c_vec).empty()
+
 cdef class STFInstReaderIterator:
     def __next__(self):
         if self.c_it == self.c_end_it:
@@ -24,11 +45,11 @@ cdef class STFInstReader:
                   size_t buffer_size = __DEFAULT_BUFFER_SIZE,
                   bint force_single_threaded_stream = False):
         self.c_reader = new _STFInstReader(filename,
-                                          only_user_mode,
-                                          enable_address_translation,
-                                          filter_mode_change_events,
-                                          buffer_size,
-                                          force_single_threaded_stream)
+                                           only_user_mode,
+                                           enable_address_translation,
+                                           filter_mode_change_events,
+                                           buffer_size,
+                                           force_single_threaded_stream)
 
     def __dealloc__(self):
         del self.c_reader
@@ -44,3 +65,12 @@ cdef class STFInstReader:
 
     def close(self):
         dereference(self.c_reader).close()
+
+    def getMajorVersion(self):
+        return self.c_reader.major()
+
+    def getMinorVersion(self):
+        return self.c_reader.minor()
+
+    def getHeaderComments(self):
+        return StringVector._construct(dereference(self.c_reader).getHeaderCommentsString())

--- a/stfpy/stfpy/stf_inst_reader.pyx
+++ b/stfpy/stfpy/stf_inst_reader.pyx
@@ -7,7 +7,7 @@ from stfpy.stf_inst import STFInst
 from cython.operator cimport dereference, preincrement
 include "stfpy/stf_lib/stf_reader_constants.pxi"
 
-cdef class StringVectorIterator:
+cdef class HeaderCommentsTypeIterator:
     def __next__(self):
         if self.c_it == self.c_end_it:
             raise StopIteration
@@ -15,9 +15,9 @@ cdef class StringVectorIterator:
         preincrement(self.c_it)
         return value
 
-cdef class StringVector:
+cdef class HeaderCommentsType:
     def __iter__(self):
-        return StringVectorIterator._construct(self.c_vec)
+        return HeaderCommentsTypeIterator._construct(self.c_vec)
 
     def __len__(self):
         return dereference(self.c_vec).size()
@@ -73,4 +73,4 @@ cdef class STFInstReader:
         return self.c_reader.minor()
 
     def getHeaderComments(self):
-        return StringVector._construct(dereference(self.c_reader).getHeaderCommentsString())
+        return HeaderCommentsType._construct(dereference(self.c_reader).getHeaderCommentsString())

--- a/stfpy/stfpy/stf_lib/stf_inst_reader.pxd
+++ b/stfpy/stfpy/stf_lib/stf_inst_reader.pxd
@@ -5,8 +5,8 @@ from libcpp.vector cimport vector
 from cython.cimports.libcpp.string import string
 from stfpy.stf_lib.stf_inst cimport STFInst
 
-ctypedef vector[string] StringVector
-ctypedef vector[string].const_iterator StringVectorIterator
+ctypedef vector[string] HeaderCommentsType
+ctypedef vector[string].const_iterator HeaderCommentsTypeIterator
 
 cdef extern from "stf_inst_reader.hpp" namespace "stf":
     cdef cppclass STFInstReader:
@@ -25,4 +25,4 @@ cdef extern from "stf_inst_reader.hpp" namespace "stf":
         iterator end()
         uint32_t major()
         uint32_t minor()
-        const StringVector& getHeaderCommentsString()
+        const HeaderCommentsType& getHeaderCommentsString()

--- a/stfpy/stfpy/stf_lib/stf_inst_reader.pxd
+++ b/stfpy/stfpy/stf_lib/stf_inst_reader.pxd
@@ -1,6 +1,12 @@
 # distutils: language = c++
 
+from libc.stdint cimport *
+from libcpp.vector cimport vector
+from cython.cimports.libcpp.string import string
 from stfpy.stf_lib.stf_inst cimport STFInst
+
+ctypedef vector[string] StringVector
+ctypedef vector[string].const_iterator StringVectorIterator
 
 cdef extern from "stf_inst_reader.hpp" namespace "stf":
     cdef cppclass STFInstReader:
@@ -17,3 +23,6 @@ cdef extern from "stf_inst_reader.hpp" namespace "stf":
         void close()
         iterator begin()
         iterator end()
+        uint32_t major()
+        uint32_t minor()
+        const StringVector& getHeaderCommentsString()


### PR DESCRIPTION
Hello @bdutro,

We have a demand to get header comments from STFInstReader via stfpy. I dug into this and came up with a patch. However I’m not sure about my implementations as follows:

- I need to get a vector of strings as type for header comments. However it was stored in STFReaderBase as `std::vector<ConstHandle<CommentRecord>>`. It was frustrating to me to implement the same interface in Cython. I kinda cheated it to add another private data member `header_comments_str_` to save comments as strings when reading the header. But not sure if that’s the best way to implement it. Do you have thoughts on this?

- I added a Cython class `StringVector` to accommodate the above data from STF C++ library. Not sure if I made(/wrote) it in the right convention/style. Let me know if it doesn’t work for you. Thanks!