### PR TITLE
Skip setting event target PC if the event was a filtered mode change

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -3,32 +3,67 @@ on:
     branches:
       - master
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   build:
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+        build_type: [Debug, Release]
+        lto_config:
+          - lto: false
+            full_lto: false
+          - lto: true
+            full_lto: false
+          - lto: true
+            full_lto: true
+        exclude:
+          # Don't try to build Debug with LTO enabled
+          - build_type: Debug
+            lto_config:
+              lto: true
+          # GCC doesn't have a thin LTO mode
+          - compiler: gcc
+            build_type: Release 
+            lto_config:
+              lto: true
+              full_lto: false
+
+    env:
+      CC: ${{ matrix.compiler }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+      LTO_CONFIG: ${{ matrix.build_type == 'Release' && format('-DNO_STF_LTO={0}', !matrix.lto_config.lto) || '' }}
+      CLANG_FULL_LTO_CONFIG: ${{ (matrix.compiler == 'clang' && matrix.build_type == 'Release') && format('-DFULL_LTO={0}', matrix.lto_config.full_lto) || '' }}
+
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
+
+    - uses: actions/checkout@v4
 
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y install libboost-dev
+        sudo apt-get -y install libboost-dev cython3
+
+    - name: Install Clang
+      run: |
+        sudo apt-get -y install clang lld llvm
+      if: ${{ matrix.compiler == 'clang' }}
 
     - name: Create Build Directory
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMAKE
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STF_PYTHON_LIB=ON $LTO_CONFIG $CLANG_FULL_LTO_CONFIG
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config ${{ matrix.build_type }} -j ${{ steps.cpu-cores.outputs.count }}
 
     - name: Regress
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target regress
+      run: cmake --build . --config ${{ matrix.build_type }} -j ${{ steps.cpu-cores.outputs.count }} --target regress

--- a/cmake/stf_linker_setup.cmake
+++ b/cmake/stf_linker_setup.cmake
@@ -142,6 +142,7 @@ function(setup_stf_linker set_compiler_options)
     set(CMAKE_AR  "gcc-ar" PARENT_SCOPE)
   endif()
 
+  set(STF_LINK_FLAGS "${STF_LINK_FLAGS}" PARENT_SCOPE)
   set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>" PARENT_SCOPE)
   set(CMAKE_CXX_ARCHIVE_FINISH   true PARENT_SCOPE)
 endfunction()

--- a/stf-inc/stf_exception.hpp
+++ b/stf-inc/stf_exception.hpp
@@ -115,6 +115,9 @@ namespace stf
                 reason_(std::move(reason))
             { }
 
+            STFException(const STFException&) = default;
+            STFException(STFException&&) = default;
+
             /// Destroy!
             inline ~STFException() noexcept override = default;
 

--- a/stf-inc/stf_inst_reader.hpp
+++ b/stf-inc/stf_inst_reader.hpp
@@ -100,6 +100,7 @@ namespace stf {
 #endif
 
                 bool event_valid = false;
+                bool filtered_mode_change = false;
 
                 updateSkipping_();
 
@@ -210,6 +211,7 @@ namespace stf {
                                     if(STF_EXPECT_FALSE((onlyUserMode_() || filter_mode_change_events_) &&
                                                         is_mode_change)) {
                                         // Filter out mode change events when mode skipping or if it is explicitly required
+                                        filtered_mode_change = true;
                                         break;
                                     }
 
@@ -219,7 +221,10 @@ namespace stf {
 
                             case IntDescriptor::STF_EVENT_PC_TARGET:
                                 stf_assert(event_valid, "Saw EventPCTargetRecord without accompanying EventRecord");
-                                delegates::STFInstDelegate::setLastEventTarget_(inst, rec);
+                                if(!filtered_mode_change)
+                                {
+                                    delegates::STFInstDelegate::setLastEventTarget_(inst, rec);
+                                }
                                 event_valid = false;
                                 break;
 

--- a/stf-inc/stf_object.hpp
+++ b/stf-inc/stf_object.hpp
@@ -207,6 +207,9 @@ namespace stf {
              * \note Name chosen to avoid collision in Spike codebase
              */
             virtual void pack(STFOFstream& writer) const = 0;
+            STFBaseObject() = default;
+            STFBaseObject(const STFBaseObject&) = default;
+            STFBaseObject(STFBaseObject&&) = default;
             virtual inline ~STFBaseObject() = default;
     };
 

--- a/stfpy/CMakeLists.txt
+++ b/stfpy/CMakeLists.txt
@@ -20,7 +20,7 @@ get_directory_property(include_dirs INCLUDE_DIRECTORIES)
 get_directory_property(compile_opts COMPILE_OPTIONS)
 get_directory_property(link_opts LINK_OPTIONS)
 
-set(stfpy_link_opts ${link_opts} ${STF_LINK_FLAGS})
+set(stfpy_link_opts $ENV{LDFLAGS} ${link_opts} ${STF_LINK_FLAGS})
 
 set(extra_lib_dirs $<TARGET_FILE_DIR:stf>)
 string(REPLACE ";" ":" include_dirs "${include_dirs}")

--- a/stfpy/CMakeLists.txt
+++ b/stfpy/CMakeLists.txt
@@ -20,7 +20,7 @@ get_directory_property(include_dirs INCLUDE_DIRECTORIES)
 get_directory_property(compile_opts COMPILE_OPTIONS)
 get_directory_property(link_opts LINK_OPTIONS)
 
-set(stfpy_link_opts $ENV{LDFLAGS} ${link_opts} ${STF_LINK_FLAGS})
+string(JOIN " " stfpy_link_opts $ENV{LDFLAGS} ${link_opts})
 
 set(extra_lib_dirs $<TARGET_FILE_DIR:stf>)
 string(REPLACE ";" ":" include_dirs "${include_dirs}")
@@ -52,7 +52,7 @@ add_custom_command(
                                   CXX="${CMAKE_CXX_COMPILER}"
                                   LD="${CMAKE_CXX_COMPILER}"
                                   CPPFLAGS="${compile_opts}"
-                                  LDFLAGS="${stfpy_link_opts}"
+                                  LDFLAGS=${stfpy_link_opts}
                                   STFPY_BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}"
                                   ${Python3_EXECUTABLE} setup.py build_ext -f
                                                                            ${CYTHON_PARALLEL_FLAG}

--- a/stfpy/CMakeLists.txt
+++ b/stfpy/CMakeLists.txt
@@ -20,6 +20,8 @@ get_directory_property(include_dirs INCLUDE_DIRECTORIES)
 get_directory_property(compile_opts COMPILE_OPTIONS)
 get_directory_property(link_opts LINK_OPTIONS)
 
+set(stfpy_link_opts ${link_opts} ${STF_LINK_FLAGS})
+
 set(extra_lib_dirs $<TARGET_FILE_DIR:stf>)
 string(REPLACE ";" ":" include_dirs "${include_dirs}")
 string(REPLACE ";" ":" extra_lib_dirs "${extra_lib_dirs}")
@@ -50,7 +52,7 @@ add_custom_command(
                                   CXX="${CMAKE_CXX_COMPILER}"
                                   LD="${CMAKE_CXX_COMPILER}"
                                   CPPFLAGS="${compile_opts}"
-                                  LDFLAGS="${link_opts}"
+                                  LDFLAGS="${stfpy_link_opts}"
                                   STFPY_BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}"
                                   ${Python3_EXECUTABLE} setup.py build_ext -f
                                                                            ${CYTHON_PARALLEL_FLAG}

--- a/tests/stf_writer_test/CMakeLists.txt
+++ b/tests/stf_writer_test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_compile_options(
     -Woverloaded-virtual
     -Wno-unused-parameter
     -Wno-missing-field-initializers
+    -Wno-unused-command-line-argument
 )
 
 add_compile_options($<$<CONFIG:Release>:-Ofast>)


### PR DESCRIPTION
Also cleans up stfpy link flag handling and some compilation errors with newer compilers.