### PR TITLE
Rename STF regress target

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -66,4 +66,4 @@ jobs:
 
     - name: Regress
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config ${{ matrix.build_type }} -j ${{ steps.cpu-cores.outputs.count }} --target regress
+      run: cmake --build . --config ${{ matrix.build_type }} -j ${{ steps.cpu-cores.outputs.count }} --target stf_regress

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,9 +16,9 @@ message(STATUS "Found " ${NUM_CORES} " cores in machine (for ctest)")
 
 add_subdirectory(stf_writer_test)
 
-add_custom_target(regress)
-add_dependencies(regress stf stf_writer_test)
+add_custom_target(stf_regress)
+add_dependencies(stf_regress stf stf_writer_test)
 
-add_custom_command(TARGET regress POST_BUILD
+add_custom_command(TARGET stf_regress POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E echo "Running tests..."
                    COMMAND ${CMAKE_CTEST_COMMAND})


### PR DESCRIPTION
Now that stf_lib is a submodule of the Atlas repo, we need to rename this regress target. When we build Atlas using SPARTA_SEARCH_DIR, we will have these targets:

```
regress [sparta]
stf_regress
atlas_regress
```

Without these changes, both the Sparta and STF regress targets clash with the same name.