### PR TITLE
Improve STFBranchDecoder handling of Zcmp and Zcmt extensions

### DIFF
--- a/lib/stf_reader.cpp
+++ b/lib/stf_reader.cpp
@@ -7,6 +7,7 @@
 #include "stf_record_types.hpp"
 #include "stf_writer.hpp"
 #include "stf_isa_defaults.hpp"
+#include "stf_isa_utils.hpp"
 
 namespace stf {
     STFReader::STFReader(const std::string_view filename, const bool force_single_threaded_stream) {
@@ -118,6 +119,15 @@ namespace stf {
         }
         stf_assert(complete_header, "STF ended with an incomplete header!");
         validateHeader_();
+
+        if(getISA() == ISA::RISCV) {
+            const std::string& isa_string = getISAExtendedInfo();
+            // Zcmp and Zcmt are automatically enabled if Zce is present
+            const bool has_zce = RISCVISAStringParser::hasExtension(isa_string, "zce");
+            // Otherwise, check if Zcmp and Zcmt are explicitly present
+            has_zcmp_ = has_zce || RISCVISAStringParser::hasExtension(isa_string, "zcmp");
+            has_zcmt_ = has_zce || RISCVISAStringParser::hasExtension(isa_string, "zcmt");
+        }
     }
 
     // cppcheck-suppress unusedFunction
@@ -160,6 +170,8 @@ namespace stf {
         initial_process_id_.reset();
         vlen_config_.reset();
         isa_extended_.reset();
+        has_zcmp_ = false;
+        has_zcmt_ = false;
 
         return STFReaderBase::close();
     }

--- a/stf-inc/stf_branch_decoder.hpp
+++ b/stf-inc/stf_branch_decoder.hpp
@@ -65,6 +65,8 @@ namespace stf {
              * \param[in] iem Instruction encoding mode
              * \param[in] pc Instruction PC
              * \param[in] opcode Instruction opcode
+             * \param[in] has_zcmp If true, enable Zcmp extension
+             * \param[in] has_zcmt If true, enable Zcmt extension
              * \param[out] target Branch target PC (only set for non-indirect branches)
              * \param[out] rs1 Number of first source register (if any)
              * \param[out] rs2 Number of second source register (if any)
@@ -84,6 +86,8 @@ namespace stf {
             static constexpr bool decodeBranch16_(const INST_IEM iem,
                                                   const uint64_t pc,
                                                   const uint16_t opcode,
+                                                  const bool has_zcmp,
+                                                  const bool has_zcmt,
                                                   uint64_t& target,
                                                   Registers::STF_REG& rs1,
                                                   Registers::STF_REG& rs2,
@@ -175,13 +179,35 @@ namespace stf {
                         break;
                     }
                     case 0b101:
-                        // popret/popretz
+                        // cm.popret/cm.popretz/cm.jt/cm.jalt
                         if(STF_EXPECT_FALSE(opcode_bottom == 0b10)) {
+                            if(!has_zcmp && !has_zcmt) {
+                                return false;
+                            }
+
                             const auto funct = byte_utils::getBitRange<12, 8, 4>(opcode);
 
                             if(funct != 0b11100 && funct != 0b11110) {
-                                return false;
+                                if(!has_zcmt) {
+                                    return false;
+                                }
+
+                                if(funct >> 2 != 0b000) {
+                                    return false;
+                                }
+
+                                // cm.jalt if true, otherwise cm.jt
+                                is_call = byte_utils::getBitRange<9, 2, 7>(opcode) >= 32;
+
+                                if(is_call) {
+                                    rd = Registers::STF_REG::STF_REG_X1;
+                                }
+
+                                is_indirect = true;
+                                return true;
                             }
+
+                            // cm.popret/cm.popretz
                             is_indirect = true;
                             is_return = true;
 
@@ -324,6 +350,8 @@ namespace stf {
              * Decodes a compressed RISCV instruction record, returning true if it is a branch.
              * \param[in] iem Instruction encoding mode
              * \param[in] rec Instruction record
+             * \param[in] has_zcmp If true, enable Zcmp extension
+             * \param[in] has_zcmt If true, enable Zcmt extension
              * \param[out] target Branch target PC (only set for non-indirect branches)
              * \param[out] rs1 Number of first source register (if any)
              * \param[out] rs2 Number of second source register (if any)
@@ -343,6 +371,8 @@ namespace stf {
             __attribute__((hot, always_inline))
             static inline bool decodeBranch_(const INST_IEM iem,
                                              const InstOpcode16Record& rec,
+                                             const bool has_zcmp,
+                                             const bool has_zcmt,
                                              uint64_t& target,
                                              Registers::STF_REG& rs1,
                                              Registers::STF_REG& rs2,
@@ -363,6 +393,8 @@ namespace stf {
                 return decodeBranch16_(iem,
                                        rec.getPC(),
                                        rec.getOpcode(),
+                                       has_zcmp,
+                                       has_zcmt,
                                        target,
                                        rs1,
                                        rs2,
@@ -384,6 +416,8 @@ namespace stf {
              * Decodes a regular RISCV instruction record, returning true if it is a branch.
              * \param[in] iem Instruction encoding mode
              * \param[in] rec Instruction record
+             * \param[in] (ignored)
+             * \param[in] (ignored)
              * \param[out] target Branch target PC (only set for non-indirect branches)
              * \param[out] rs1 Number of first source register (if any)
              * \param[out] rs2 Number of second source register (if any)
@@ -403,6 +437,8 @@ namespace stf {
             __attribute__((hot, always_inline))
             static inline bool decodeBranch_(const INST_IEM,
                                              const InstOpcode32Record& rec,
+                                             const bool,
+                                             const bool,
                                              uint64_t& target,
                                              Registers::STF_REG& rs1,
                                              Registers::STF_REG& rs2,
@@ -444,6 +480,8 @@ namespace stf {
              * Decodes a RISCV instruction record, returning true if it is a branch.
              * \param[in] iem Instruction encoding mode
              * \param[in] rec Instruction record
+             * \param[in] has_zcmp If true, enable Zcmp extension
+             * \param[in] has_zcmt If true, enable Zcmt extension
              * \param[out] target Branch target PC (only set for non-indirect branches)
              * \param[out] rs1 Number of first source register (if any)
              * \param[out] rs2 Number of second source register (if any)
@@ -465,6 +503,8 @@ namespace stf {
             __attribute__((hot, always_inline))
             static inline bool decode(const INST_IEM iem,
                                       const RecordType& rec,
+                                      const bool has_zcmp,
+                                      const bool has_zcmt,
                                       uint64_t& target,
                                       Registers::STF_REG& rs1,
                                       Registers::STF_REG& rs2,
@@ -483,6 +523,8 @@ namespace stf {
                                       bool& compare_unsigned) {
                 return decodeBranch_(iem,
                                      rec,
+                                     has_zcmp,
+                                     has_zcmt,
                                      target,
                                      rs1,
                                      rs2,
@@ -506,12 +548,16 @@ namespace stf {
              * This variant is used by STFBranchReader to initialize STFBranch objects.
              * \param[in] iem Instruction encoding mode
              * \param[in] rec Instruction record
+             * \param[in] has_zcmp If true, enable Zcmp extension
+             * \param[in] has_zcmt If true, enable Zcmt extension
              * \param[out] branch STFBranch object to be initialized if the instruction is a branch
              */
             template<typename RecordType>
             __attribute__((hot, always_inline))
             static inline bool decode(const INST_IEM iem,
                                       const RecordType& rec,
+                                      const bool has_zcmp,
+                                      const bool has_zcmt,
                                       STFBranch& branch) {
                 uint64_t target = 0;
                 Registers::STF_REG rs1;
@@ -532,6 +578,8 @@ namespace stf {
 
                 const bool is_branch = decode(iem,
                                               rec,
+                                              has_zcmp,
+                                              has_zcmt,
                                               target,
                                               rs1,
                                               rs2,
@@ -579,10 +627,15 @@ namespace stf {
              * Returns whether the specified instruction record is a branch.
              * \param iem Instruction encoding mode
              * \param rec Instruction record
+             * \param has_zcmp If true, enable Zcmp extension
+             * \param has_zcmt If true, enable Zcmt extension
              */
             template<typename RecordType>
             __attribute__((hot, always_inline))
-            static inline bool isBranch(const INST_IEM iem, const RecordType& rec) {
+            static inline bool isBranch(const INST_IEM iem,
+                                        const RecordType& rec,
+                                        const bool has_zcmp,
+                                        const bool has_zcmt) {
                 uint64_t target = 0;
                 Registers::STF_REG rs1 = Registers::STF_REG::STF_REG_INVALID;
                 Registers::STF_REG rs2 = Registers::STF_REG::STF_REG_INVALID;
@@ -602,6 +655,8 @@ namespace stf {
 
                 return decode(iem,
                               rec,
+                              has_zcmp,
+                              has_zcmt,
                               target,
                               rs1,
                               rs2,

--- a/stf-inc/stf_branch_reader.hpp
+++ b/stf-inc/stf_branch_reader.hpp
@@ -126,7 +126,7 @@ namespace stf {
                 const bool skip_item = skippingEnabled_();
                 countSkippedInst_(skip_item);
 
-                if(STF_EXPECT_TRUE(!STFBranchDecoder::decode(getInitialIEM(), inst_rec, branch))) {
+                if(STF_EXPECT_TRUE(!STFBranchDecoder::decode(getInitialIEM(), inst_rec, ParentReader::hasZcmp(), ParentReader::hasZcmt(), branch))) {
                     stf_assert(!branch.isTaken(), "Branch was marked taken but also didn't decode as a branch");
                     delegates::STFBranchDelegate::reset_(branch);
                     resetOperandMaps_();

--- a/stf-inc/stf_inst.hpp
+++ b/stf-inc/stf_inst.hpp
@@ -2170,6 +2170,8 @@ namespace stf {
 #ifdef STF_INST_HAS_IEM
                                                 const bool iem_changed,
 #endif
+                                                const bool has_zcmp,
+                                                const bool has_zcmt,
                                                 const uint32_t hw_thread_id,
                                                 const uint32_t pid,
                                                 const uint32_t tid,
@@ -2184,7 +2186,7 @@ namespace stf {
                     inst.iem_changed_ = iem_changed;
 #endif
                     inst.setSkipped_(is_skipped);
-                    inst.setInstFlag_(math_utils::conditionalValue(STFBranchDecoder::isBranch(iem, rec), STFInst::INST_IS_BRANCH,
+                    inst.setInstFlag_(math_utils::conditionalValue(STFBranchDecoder::isBranch(iem, rec, has_zcmp, has_zcmt), STFInst::INST_IS_BRANCH,
                                                                    is_compressed, STFInst::INST_OPCODE16));
                     inst.hw_thread_id_ = hw_thread_id;
                     inst.pid_ = pid;

--- a/stf-inc/stf_inst_reader.hpp
+++ b/stf-inc/stf_inst_reader.hpp
@@ -308,6 +308,8 @@ namespace stf {
 #ifdef STF_INST_HAS_IEM
                                                          iem_changed_,
 #endif
+                                                         ParentReader::hasZcmp(),
+                                                         ParentReader::hasZcmt(),
                                                          hw_thread_id_,
                                                          pid_,
                                                          tid_,

--- a/stf-inc/stf_isa_utils.hpp
+++ b/stf-inc/stf_isa_utils.hpp
@@ -1,0 +1,94 @@
+#ifndef __STF_ISA_UTILS_HPP__
+#define __STF_ISA_UTILS_HPP__
+
+#include <string>
+
+namespace stf {
+    /**
+     * \class RISCVISAStringParser
+     * Provides *very* rudimentary RISC-V ISA string parsing
+     * Right now this can only determine if an extension appears in an ISA string
+     */
+    class RISCVISAStringParser {
+        private:
+            static inline bool findMulticharExtension_(const std::string& isa_string, const std::string& extension, size_t start_pos = 0) {
+                const auto search_str = std::string(1, '_') + extension;
+
+                const auto find_next = [&isa_string, &search_str, &start_pos]() {
+                    return isa_string.find(search_str, start_pos);
+                };
+
+                for(auto pos = find_next(); pos != std::string::npos; pos = find_next()) {
+                    // We only reach this point if the extension's string appears somewhere in the ISA string
+                    const auto search_str_end = pos + search_str.size();
+
+                    // For a multi-character extension ext, it will appear in one of the following forms:
+                    // 1. _ext (at the end of the ISA string)
+                    // 2. _ext_ (somewhere in the middle of the ISA string)
+                    // 3. _ext[0-9] (anywhere in the string. The number indicates the extension version)
+
+                    // First check for case 1
+                    if(search_str_end == isa_string.size()) {
+                        return true;
+                    }
+
+                    // Check for cases 2 and 3. The main point of this is to make sure we aren't accidentally
+                    // matching against part of another extension substring
+                    const auto end_of_extension = isa_string.find_first_of("0123456789_", search_str_end);
+
+                    // If none of the end-of-extension characters appear in the string, then this extension can't be present
+                    if(end_of_extension == std::string::npos) {
+                        return false;
+                    }
+
+                    // If an end-of-extension character appears right after the end of the extension string we're done
+                    if(end_of_extension == search_str_end) {
+                        return true;
+                    }
+
+                    // Otherwise search again
+                    start_pos = end_of_extension;
+                }
+
+                return false;
+            }
+
+        public:
+            static inline bool hasExtension(const std::string& isa_string, const char extension) {
+                size_t i = 0;
+
+                // RISC-V ISA strings have all single-character extensions at the beginning of the string.
+                // These do not have to be separated by _ characters
+                for(; i < isa_string.size(); ++i) {
+                    // If we find the character before the first _, we're done
+                    if(const auto ch = isa_string[i]; ch == extension) {
+                        return true;
+                    }
+
+                    // Once we reach the first _ character, we need to use a different method to search the
+                    // ISA string
+                    else if(ch == '_') {
+                        break;
+                    }
+                }
+
+                if(i == isa_string.size()) {
+                    return false;
+                }
+
+                // At this point we can treat it identically to a multi-character extension
+                return findMulticharExtension_(isa_string, std::string(1, extension), i);
+            }
+
+            static inline bool hasExtension(const std::string& isa_string, const std::string& extension) {
+                // Use the single-character method if this is a single-character extension
+                if(extension.size() == 1) {
+                    return hasExtension(isa_string, extension.front());
+                }
+
+                return findMulticharExtension_(isa_string, extension);
+            }
+    };
+}
+
+#endif

--- a/stf-inc/stf_reader.hpp
+++ b/stf-inc/stf_reader.hpp
@@ -40,6 +40,8 @@ namespace stf {
             STFRecord::ConstHandle<ProcessIDExtRecord> initial_process_id_;
             STFRecord::ConstHandle<VLenConfigRecord> vlen_config_;
             STFRecord::ConstHandle<ISAExtendedRecord> isa_extended_;
+            bool has_zcmp_ = false;
+            bool has_zcmt_ = false;
 
             /**
              * Reads the STF header
@@ -132,6 +134,20 @@ namespace stf {
              */
             inline vlen_t getVLen() const {
                 return stream_->getVLen();
+            }
+
+            /**
+             * Gets whether the RISC-V Zcmp extension is enabled in this trace
+             */
+            inline bool hasZcmp() const {
+                return has_zcmp_;
+            }
+
+            /**
+             * Gets whether the RISC-V Zcmt extension is enabled in this trace
+             */
+            inline bool hasZcmt() const {
+                return has_zcmt_;
             }
     };
 } // end namespace stf


### PR DESCRIPTION
    - Only decode cm.popret/cm.popretz if Zcmp is enabled in the trace's ISA string
    - Only decode cm.jt/cm.jalt if Zcmt is enabeld in the ISA string
    - Automatically detect the presence of Zcmp and Zcmt in RISC-V traces